### PR TITLE
Update build config with -DLLAMA_CURL=OFF

### DIFF
--- a/lib/modules/Toolbox-Functions.psm1
+++ b/lib/modules/Toolbox-Functions.psm1
@@ -355,7 +355,7 @@ function BuildLlama {
 
     Set-Location $path\llama.cpp
 
-    $cmakeArgs1 = "-B .\build $buildFlag -DGGML_NATIVE=ON"
+    $cmakeArgs1 = "-B .\build $buildFlag -DGGML_NATIVE=ON -DLLAMA_CURL=OFF"
     $cmakeArgs2 = "--build build --config Release -j $NumberOfCores"
 
     Write-Warning "Running CMake configure"


### PR DESCRIPTION
I installed curl via chocolatey on my system and added it to path, but llama.cpp doesn't detect curl on my system. I also did `python -m pip install -r requirements-all.txt` in `Llama.Cpp-Toolbox\llama.cpp\requirements`, but it still doesn't detect curl. This is the error I get:
```shell
-- Could NOT find CURL (missing: CURL_LIBRARY CURL_INCLUDE_DIR)
CMake Error at common/CMakeLists.txt:92 (message):
  Could NOT find CURL.  Hint: to disable this feature, set -DLLAMA_CURL=OFF

-- Configuring incomplete, errors occurred!
```


Under `llama.cpp\windows-setup-curl`, there is a file called `action-yml` with the following contents:

```yaml
name: 'Windows - Setup CURL'
description: 'Composite action, to be reused in other workflow'
inputs:
  curl_version:
    description: 'CURL version'
    required: false
    default: '8.6.0_6'
outputs:
  curl_path:
    description: "Path to the downloaded libcurl"
    value: ${{ steps.get_libcurl.outputs.curl_path }}

runs:
  using: "composite"
  steps:
    - name: libCURL
      id: get_libcurl
      shell: powershell
      env:
        CURL_VERSION: ${{ inputs.curl_version }}
      run: |
        curl.exe -o $env:RUNNER_TEMP/curl.zip -L "https://curl.se/windows/dl-${env:CURL_VERSION}/curl-${env:CURL_VERSION}-win64-mingw.zip"
        mkdir $env:RUNNER_TEMP/libcurl
        tar.exe -xvf $env:RUNNER_TEMP/curl.zip --strip-components=1 -C $env:RUNNER_TEMP/libcurl
        echo "curl_path=$env:RUNNER_TEMP/libcurl" >> $env:GITHUB_OUTPUT
```
I am not quite sure what's wrong with it and why curl is not contained in the requirements file.

Finally, as a last effort, I followed the recommendation in the error message and set  `-DLLAMA_CURL=OFF`, which allowed me to compile llama.cpp with the llama.cpp-toolbox again. Success.

Hence, for now, I propose to set this flag in the toolbox.